### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/python_lint_and_test.yml
+++ b/.github/workflows/python_lint_and_test.yml
@@ -35,6 +35,16 @@ jobs:
     - name: Lint with PyLint
       run: |
         pylint --disable=W0718,R0911,R0903,R0915 $(git ls-files '*.py')
-    - name: Test with pytest
+    - name: Test with pytest and export to xml
       run: |
-        pytest
+        coverage run -m pytest && coverage xml
+    - name: Print coverage report
+      run: |
+        coverage report -m
+    # Only need to push the coverage report once
+    - name: Push coverage to PR
+      if: matrix.python-version == '3.9'
+      uses: orgoro/coverage@v3.2
+      with:
+        coverageFile: coverage.xml
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/prism_vnc_proxy.py
+++ b/prism_vnc_proxy.py
@@ -119,6 +119,7 @@ def main():
     """
     opts = parse_opts()
     if opts is None:
+        log.error("Failed to parse command line options")
         return 1
 
     # Configure the prism websocket handler. Local requests to /proxy/<vm_uuid>

--- a/prism_vnc_proxy_test.py
+++ b/prism_vnc_proxy_test.py
@@ -8,6 +8,8 @@ Tests included:
 - `test_parse_opts_missing_required`: Ensures that `parse_opts` raises a
     SystemExit when required arguments are missing.
 - `test_main`: Tests the `main` function of the `prism_vnc_proxy` module.
+- `test_main_opts_none`: Ensures that the `main` function returns 1 when
+    options parsing fails.
 
 Logging:
     Logging is configured to output debug information to assist in tracing the
@@ -122,3 +124,25 @@ async def test_main(monkeypatch):
     logger.debug("Main function result: %d", result)
     assert result == 0
     logger.debug("Finished test_main")
+
+
+def test_main_opts_none(monkeypatch):
+    """
+    Test the main function to ensure it returns 1 when options parsing fails.
+
+    This test uses the monkeypatch fixture to modify the parse_opts function
+    to return None, simulating a failure in options parsing.
+
+    Args:
+        monkeypatch: A pytest fixture that allows modifying or simulating
+                     attributes and functions.
+
+    Assertions:
+        Asserts that the main function returns 1.
+    """
+    logger.debug("Starting test_main_opts_none")
+    monkeypatch.setattr('prism_vnc_proxy.parse_opts', lambda: None)
+    result = main()
+    logger.debug("Main function result when opts is None: %d", result)
+    assert result == 1
+    logger.debug("Finished test_main_opts_none")

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,8 @@
 flake8
+twisted
 pylint
 pytest
 pytest-aiohttp
 pytest-asyncio
+pytest-cov
+pytest-twisted

--- a/wsgi_file_handler_test.py
+++ b/wsgi_file_handler_test.py
@@ -7,10 +7,7 @@ The tests are designed to verify the following scenarios:
     404 status code with the message "File not found".
 2. Forbidden Path: Ensures that requests for forbidden paths (e.g., paths
     containing "..") return a 404 status code.
-3. Internal Server Error: Ensures that an internal server error is properly
-    handled and returns a 500 status code with the message "Internal server
-    error".
-4. Serve File: Ensures that a valid file request returns a 200 status code
+3. Serve File: Ensures that a valid file request returns a 200 status code
     and serves the correct file content.
 
 Classes:
@@ -24,17 +21,12 @@ Functions:
         exist.
      test_forbidden_path: Tests the scenario where a requested path is
         forbidden.
-     test_internal_server_error: Tests the scenario where an internal server
-        error occurs.
      test_serve_file: Tests the scenario where a valid file is requested and
         served.
 
 Logging:
      Configured to log at the INFO level. Debug logs are used within test
      methods to trace the execution flow.
-
-Usage:
-     Run this module directly to execute the tests using pytest.
 
 Author:
     Jon Kohler (jon@nutanix.com)
@@ -45,7 +37,6 @@ Copyright:
 
 import os
 import logging
-import pytest
 
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase
@@ -67,8 +58,6 @@ class TestWSGIFileHandler(AioHTTPTestCase):
       exist.
     - test_forbidden_path: Tests the scenario where a forbidden path is
       requested.
-    - test_internal_server_error: Tests the scenario where an internal server
-      error occurs.
     - test_serve_file: Tests the scenario where a file is successfully served.
 
     Each test method sends an HTTP GET request to the application and asserts
@@ -128,34 +117,6 @@ class TestWSGIFileHandler(AioHTTPTestCase):
         assert request.status == 404
         logger.debug("Forbidden path test passed")
 
-    async def test_internal_server_error(self):
-        """
-        Test case for simulating an internal server error scenario.
-
-        This test verifies that when an internal server error occurs, the
-        server responds with a status code of 500 and the response text is
-        "Internal server error".
-
-        Steps:
-        1. Send a GET request to the root endpoint ("/").
-        2. Assert that the response status code is 500.
-        3. Assert that the response text is "Internal server error".
-
-        The test expects an exception to be raised during the request,
-        indicating that an internal server error has occurred.
-
-        Raises:
-            Exception: If the request does not result in an internal server
-            error.
-        """
-        logger.debug("Testing internal server error scenario")
-        with pytest.raises(Exception):
-            request = await self.client.request("GET", "/")
-            assert request.status == 500
-            text = await request.text()
-            assert text == "Internal server error"
-        logger.debug("Internal server error test passed")
-
     async def test_serve_file(self):
         """
         Test the file serving functionality of the application.
@@ -191,9 +152,3 @@ class TestWSGIFileHandler(AioHTTPTestCase):
 
         os.remove(file_path)
         logger.debug("Test file removed")
-
-
-if __name__ == '__main__':
-    logger.info("Starting tests")
-    pytest.main()
-    logger.info("Finished tests")

--- a/wsgi_prism_websocket_proxy_test.py
+++ b/wsgi_prism_websocket_proxy_test.py
@@ -107,6 +107,33 @@ async def test_prism_websocket_handler_missing_uuid(proxy):
 
 
 @pytest.mark.asyncio
+async def test_prism_websocket_handler_invalid_vm_uuid(proxy):
+    """
+    Test the `prism_websocket_handler` method of the proxy with an invalid VM
+    UUID.
+
+    This test ensures that the `prism_websocket_handler` method correctly
+    handles the case where an invalid VM UUID is provided. It verifies that
+    an HTTPBadRequest exception is raised.
+
+    Args:
+        proxy: The proxy instance being tested.
+
+    Assertions:
+        - The response status code should be 400.
+        - The response text should indicate that the VM UUID format is
+          invalid.
+    """
+    logger.debug("Starting test_prism_websocket_handler_invalid_vm_uuid")
+    request = MagicMock()
+    request.match_info.get.return_value = "invalid-uuid"
+    response = await proxy.prism_websocket_handler(request)
+    assert response.status == 400
+    assert response.text == "Invalid VM UUID format"
+    logger.debug("Completed test_prism_websocket_handler_invalid_vm_uuid")
+
+
+@pytest.mark.asyncio
 async def test_prism_websocket_handler_no_session_cookie(proxy, uuid4):
     """
     Test the `prism_websocket_handler` method of the `proxy` object when


### PR DESCRIPTION
- Add twisted/pytest_twisted so test_main works within venv properly
- Print coverage result in Actions log
- Post coverage result to PR
- Small product code tuneups along the way
- Incrementally expand test cases where needed
- Remove invalid test case from wsgi_file_handler_test, which wasn't
  actually doing what I originally thought it would do.